### PR TITLE
Add modulus assignment operator explanation to Assignment Operators section

### DIFF
--- a/00_python_colab/03_operators_keywords_variables/Agentic_AI_Python_Lesson_03_Operators,_Keywords_&_Variables.ipynb
+++ b/00_python_colab/03_operators_keywords_variables/Agentic_AI_Python_Lesson_03_Operators,_Keywords_&_Variables.ipynb
@@ -536,21 +536,21 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## **4. Assignment Operators**\n",
-        "Used to assign values to variables.\n",
-        "\n",
-        "<br>\n",
-        "\n",
-        "| Operator | Example | Equivalent To |\n",
-        "|----------|---------|---------------|\n",
-        "| =        | x = 5   | x = 5         |\n",
-        "| +=       | x += 3  | x = x + 3     |\n",
-        "| -=       | x -= 3  | x = x - 3     |\n",
-        "| *=       | x *= 3  | x = x * 3     |\n",
-        "| /=       | x /= 3  | x = x / 3     |\n",
-        "| //=      | x //= 3 | x = x // 3    |\n",
-        "|          |         |               |\n",
-        "|          |         |               |\n"
+        ## **4. Assignment Operators**
+Used to assign values to variables.
+
+<br>
+
+| Operator | Example | Equivalent To |
+|----------|---------|---------------|
+| =        | x = 5   | x = 5         |
+| +=       | x += 3  | x = x + 3     |
+| -=       | x -= 3  | x = x - 3     |
+| *=       | x *= 3  | x = x * 3     |
+| /=       | x /= 3  | x = x / 3     |
+| //=      | x //= 3 | x = x // 3    |
+| %=       | x %= 3  | x = x % 3     |
+|          |         |               |
       ],
       "metadata": {
         "id": "rjEUF7mWpJ3U"
@@ -575,7 +575,9 @@
         "print(\"Division Assignment: x /= 3          \",x)  # Output: 5.0\n",
         "\n",
         "x //= 3  # Equivalent to x = x // 3\n",
-        "print(\"Floor Division Assignment: x //= 3   \",x)  # Output: 1.0"
+        "print(\"Floor Division Assignment: x //= 3   \",x)  # Output: 1.0",
+        "x %= 3  # Equivalent to x = x % 3\n",
+        "print(\"Modulo Assignment: x %= 3   \",x)  # Output: 1.0"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
This PR adds a brief explanation and example for the modulus assignment operator (%=) in the Assignment Operators section.

The addition clarifies that x %= y is equivalent to x = x % y and helps improve the completeness and clarity of the lesson for beginners and students.
